### PR TITLE
feat: add isEqualsOrBefore and isEqualsOrAfter methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,8 @@ CalendarDate.fromDateTimeZone(date, 'Europe/Berlin');
 The year, month, day and unix timestamp can be accessed as read-only properties on the object.
 Since version 2 of calendar-date the month value is now in the range of 1 to 12 and not of 0 to 11 anymore.
 
-To compare to CalendarDate objects you can use the `equals`, `isBefore` and `isAfter` function or `>=`, `<=`, `>` and `<` operators.
+To compare to CalendarDate objects you can use the `equals`, `isBefore`, `isAfter`, `isBeforeOrEqual` and `isAfterOrEqual` 
+function or`>=`, `<=`, `>` and `<` operators.
 The comparison works based on the unix timestamp.
 
 ```typescript
@@ -89,6 +90,8 @@ date1 === date2       // false
 date1.equals(date3)   // false
 date1.isBefore(date3) // true
 date1.isAfter(date3)  // false
+date1.isBeforeOrEqual(date2) // true
+date1.isAfterOrEqual(date2)  // false
 date1 >= date2        // true
 date1 > date2         // false
 date1 >= date3        // false

--- a/src/CalendarDate.ts
+++ b/src/CalendarDate.ts
@@ -286,11 +286,11 @@ export class CalendarDate {
     return this.valueOf() > calendarDate.valueOf();
   }
 
-  isEqualsOrBefore(calendarDate: CalendarDate): boolean {
+  isBeforeOrEqual(calendarDate: CalendarDate): boolean {
     return this.isBefore(calendarDate) || this.equals(calendarDate);
   }
 
-  isEqualsOrAfter(calendarDate: CalendarDate): boolean {
+  isAfterOrEqual(calendarDate: CalendarDate): boolean {
     return this.isAfter(calendarDate) || this.equals(calendarDate);
   }
 

--- a/src/CalendarDate.ts
+++ b/src/CalendarDate.ts
@@ -287,11 +287,11 @@ export class CalendarDate {
   }
 
   isBeforeOrEqual(calendarDate: CalendarDate): boolean {
-    return this.isBefore(calendarDate) || this.equals(calendarDate);
+    return this.valueOf() <= calendarDate.valueOf();
   }
 
   isAfterOrEqual(calendarDate: CalendarDate): boolean {
-    return this.isAfter(calendarDate) || this.equals(calendarDate);
+    return this.valueOf() >= calendarDate.valueOf();
   }
 
   /**

--- a/src/CalendarDate.ts
+++ b/src/CalendarDate.ts
@@ -286,6 +286,14 @@ export class CalendarDate {
     return this.valueOf() > calendarDate.valueOf();
   }
 
+  isEqualsOrBefore(calendarDate: CalendarDate): boolean {
+    return this.isBefore(calendarDate) || this.equals(calendarDate);
+  }
+
+  isEqualsOrAfter(calendarDate: CalendarDate): boolean {
+    return this.isAfter(calendarDate) || this.equals(calendarDate);
+  }
+
   /**
    * Returns a new CalendarDate with the specified amount of months added.
    *

--- a/test/CalendarDate.test.ts
+++ b/test/CalendarDate.test.ts
@@ -504,8 +504,8 @@ describe('CalendarDate', () => {
     });
   });
 
-  describe('Test isEqualsOrBefore', () => {
-    test('isEqualsOrBefore returns true if the comparing date is greater', () => {
+  describe('Test isBeforeOrEqual', () => {
+    test('isBeforeOrEqual returns true if the comparing date is greater', () => {
       fc.assert(
         fc.property(
           fc.integer({ min: 200, max: 9900 }),
@@ -519,13 +519,13 @@ describe('CalendarDate', () => {
             const date2 = date1.addDays(days);
 
             // Assert
-            expect(date1.isEqualsOrBefore(date2)).toBe(true);
+            expect(date1.isBeforeOrEqual(date2)).toBe(true);
           },
         ),
       );
     });
 
-    test('isEqualsOrBefore returns true if the comparing date is equal', () => {
+    test('isBeforeOrEqual returns true if the comparing date is equal', () => {
       fc.assert(
         fc.property(
           fc.integer({ min: 200, max: 9900 }),
@@ -538,13 +538,13 @@ describe('CalendarDate', () => {
             const date2 = new CalendarDate(year, month, day);
 
             // Assert
-            expect(date1.isEqualsOrBefore(date2)).toBe(true);
+            expect(date1.isBeforeOrEqual(date2)).toBe(true);
           },
         ),
       );
     });
 
-    test('isEqualsOrAfter returns false if the comparing date is smaller', () => {
+    test('isBeforeOrEqual returns false if the comparing date is smaller', () => {
       fc.assert(
         fc.property(
           fc.integer({ min: 200, max: 9900 }),
@@ -558,15 +558,15 @@ describe('CalendarDate', () => {
             const date2 = date1.addDays(-days);
 
             // Assert
-            expect(date1.isEqualsOrBefore(date2)).toBe(false);
+            expect(date1.isBeforeOrEqual(date2)).toBe(false);
           },
         ),
       );
     });
   });
 
-  describe('Test isEqualsOrAfter', () => {
-    test('isEqualsOrAfter returns true if the comparing date is smaller', () => {
+  describe('Test isAfterOrEqual', () => {
+    test('isAfterOrEqual returns true if the comparing date is smaller', () => {
       fc.assert(
         fc.property(
           fc.integer({ min: 200, max: 9900 }),
@@ -580,13 +580,13 @@ describe('CalendarDate', () => {
             const date2 = date1.addDays(-days);
 
             // Assert
-            expect(date1.isEqualsOrAfter(date2)).toBe(true);
+            expect(date1.isAfterOrEqual(date2)).toBe(true);
           },
         ),
       );
     });
 
-    test('isEqualsOrAfter returns true if the comparing date is equal', () => {
+    test('isAfterOrEqual returns true if the comparing date is equal', () => {
       fc.assert(
         fc.property(
           fc.integer({ min: 200, max: 9900 }),
@@ -599,13 +599,13 @@ describe('CalendarDate', () => {
             const date2 = new CalendarDate(year, month, day);
 
             // Assert
-            expect(date1.isEqualsOrAfter(date2)).toBe(true);
+            expect(date1.isAfterOrEqual(date2)).toBe(true);
           },
         ),
       );
     });
 
-    test('isEqualsOrAfter returns false if the comparing date is greater', () => {
+    test('isAfterOrEqual returns false if the comparing date is greater', () => {
       fc.assert(
         fc.property(
           fc.integer({ min: 200, max: 9900 }),
@@ -619,7 +619,7 @@ describe('CalendarDate', () => {
             const date2 = date1.addDays(days);
 
             // Assert
-            expect(date1.isEqualsOrAfter(date2)).toBe(false);
+            expect(date1.isAfterOrEqual(date2)).toBe(false);
           },
         ),
       );

--- a/test/CalendarDate.test.ts
+++ b/test/CalendarDate.test.ts
@@ -504,6 +504,128 @@ describe('CalendarDate', () => {
     });
   });
 
+  describe('Test isEqualsOrBefore', () => {
+    test('isEqualsOrBefore returns true if the comparing date is greater', () => {
+      fc.assert(
+        fc.property(
+          fc.integer({ min: 200, max: 9900 }),
+          fc.integer({ min: 1, max: 12 }),
+          fc.integer({ min: 1, max: 31 }),
+          fc.integer({ min: 1, max: 1000 }),
+          (year, month, day, days) => {
+            // Arrange
+            day = ensureValidDay(year, month, day);
+            const date1 = new CalendarDate(year, month, day);
+            const date2 = date1.addDays(days);
+
+            // Assert
+            expect(date1.isEqualsOrBefore(date2)).toBe(true);
+          },
+        ),
+      );
+    });
+
+    test('isEqualsOrBefore returns true if the comparing date is equal', () => {
+      fc.assert(
+        fc.property(
+          fc.integer({ min: 200, max: 9900 }),
+          fc.integer({ min: 1, max: 12 }),
+          fc.integer({ min: 1, max: 31 }),
+          (year, month, day) => {
+            // Arrange
+            day = ensureValidDay(year, month, day);
+            const date1 = new CalendarDate(year, month, day);
+            const date2 = new CalendarDate(year, month, day);
+
+            // Assert
+            expect(date1.isEqualsOrBefore(date2)).toBe(true);
+          },
+        ),
+      );
+    });
+
+    test('isEqualsOrAfter returns false if the comparing date is smaller', () => {
+      fc.assert(
+        fc.property(
+          fc.integer({ min: 200, max: 9900 }),
+          fc.integer({ min: 1, max: 12 }),
+          fc.integer({ min: 1, max: 31 }),
+          fc.integer({ min: 1, max: 1000 }),
+          (year, month, day, days) => {
+            // Arrange
+            day = ensureValidDay(year, month, day);
+            const date1 = new CalendarDate(year, month, day);
+            const date2 = date1.addDays(-days);
+
+            // Assert
+            expect(date1.isEqualsOrBefore(date2)).toBe(false);
+          },
+        ),
+      );
+    });
+  });
+
+  describe('Test isEqualsOrAfter', () => {
+    test('isEqualsOrAfter returns true if the comparing date is smaller', () => {
+      fc.assert(
+        fc.property(
+          fc.integer({ min: 200, max: 9900 }),
+          fc.integer({ min: 1, max: 12 }),
+          fc.integer({ min: 1, max: 31 }),
+          fc.integer({ min: 1, max: 1000 }),
+          (year, month, day, days) => {
+            // Arrange
+            day = ensureValidDay(year, month, day);
+            const date1 = new CalendarDate(year, month, day);
+            const date2 = date1.addDays(-days);
+
+            // Assert
+            expect(date1.isEqualsOrAfter(date2)).toBe(true);
+          },
+        ),
+      );
+    });
+
+    test('isEqualsOrAfter returns true if the comparing date is equal', () => {
+      fc.assert(
+        fc.property(
+          fc.integer({ min: 200, max: 9900 }),
+          fc.integer({ min: 1, max: 12 }),
+          fc.integer({ min: 1, max: 31 }),
+          (year, month, day) => {
+            // Arrange
+            day = ensureValidDay(year, month, day);
+            const date1 = new CalendarDate(year, month, day);
+            const date2 = new CalendarDate(year, month, day);
+
+            // Assert
+            expect(date1.isEqualsOrAfter(date2)).toBe(true);
+          },
+        ),
+      );
+    });
+
+    test('isEqualsOrAfter returns false if the comparing date is greater', () => {
+      fc.assert(
+        fc.property(
+          fc.integer({ min: 200, max: 9900 }),
+          fc.integer({ min: 1, max: 12 }),
+          fc.integer({ min: 1, max: 31 }),
+          fc.integer({ min: 1, max: 1000 }),
+          (year, month, day, days) => {
+            // Arrange
+            day = ensureValidDay(year, month, day);
+            const date1 = new CalendarDate(year, month, day);
+            const date2 = date1.addDays(days);
+
+            // Assert
+            expect(date1.isEqualsOrAfter(date2)).toBe(false);
+          },
+        ),
+      );
+    });
+  });
+
   describe('Test of max', () => {
     test('Throws Error for no input arguments', () => {
       expect(() => CalendarDate.max()).toThrowError(


### PR DESCRIPTION
### Overview

Added `isBeforeOrEqual` and `isAfterOrEqual` methods to shorten what would otherwise be written as:
`date1.isAfter(date2) || date1.equals(date2)` or `date1.isBefore(date2) || date1.equals(date2)`