### PR TITLE
feat: add tolocalDate method

### DIFF
--- a/src/CalendarDate.ts
+++ b/src/CalendarDate.ts
@@ -263,11 +263,11 @@ export class CalendarDate {
     return this.toString();
   }
 
-  toDate(): Date {
+  toDateUTC(): Date {
     return new Date(this.unixTimestampInSeconds * 1000);
   }
 
-  toLocalDate(): Date {
+  toDateLocal(): Date {
     return new Date(this.year, this.month - 1, this.day);
   }
 

--- a/src/CalendarDate.ts
+++ b/src/CalendarDate.ts
@@ -267,6 +267,10 @@ export class CalendarDate {
     return new Date(this.unixTimestampInSeconds * 1000);
   }
 
+  toLocalDate(): Date {
+    return new Date(this.year, this.month - 1, this.day);
+  }
+
   /**
    * Returns the unix timestamp in seconds.
    */

--- a/test/CalendarDate.test.ts
+++ b/test/CalendarDate.test.ts
@@ -353,7 +353,7 @@ describe('CalendarDate', () => {
     });
   });
 
-  describe('Test of toDate', () => {
+  describe('Test of toDateUTC', () => {
     test('The returned date object represents the start of the day of the calendarDate in UTC timezone', () => {
       fc.assert(
         fc.property(
@@ -364,7 +364,7 @@ describe('CalendarDate', () => {
             // Arrange
             day = ensureValidDay(year, month, day);
             const calendarDate = new CalendarDate(year, month, day);
-            const date = calendarDate.toDate();
+            const date = calendarDate.toDateUTC();
 
             // Assert
             expect(date.toISOString()).toEqual(`${calendarDate.toString()}T00:00:00.000Z`);
@@ -374,7 +374,7 @@ describe('CalendarDate', () => {
     });
   });
 
-  describe('Test of toLocalDate', () => {
+  describe('Test of toDateLocal', () => {
     test('The returned date object represents the start of the day in the local timezone', () => {
       fc.assert(
         fc.property(
@@ -385,7 +385,7 @@ describe('CalendarDate', () => {
             // Arrange
             day = ensureValidDay(year, month, day);
             const calendarDate = new CalendarDate(year, month, day);
-            const date = calendarDate.toLocalDate();
+            const date = calendarDate.toDateLocal();
 
             // Assert
             expect(

--- a/test/CalendarDate.test.ts
+++ b/test/CalendarDate.test.ts
@@ -374,6 +374,29 @@ describe('CalendarDate', () => {
     });
   });
 
+  describe('Test of toLocalDate', () => {
+    test('The returned date object represents the start of the day in the local timezone', () => {
+      fc.assert(
+        fc.property(
+          fc.integer({ min: 200, max: 9900 }),
+          fc.integer({ min: 1, max: 12 }),
+          fc.integer({ min: 1, max: 31 }),
+          (year, month, day) => {
+            // Arrange
+            day = ensureValidDay(year, month, day);
+            const calendarDate = new CalendarDate(year, month, day);
+            const date = calendarDate.toLocalDate();
+
+            // Assert
+            expect(
+              `${date.getFullYear().toString().padStart(4, '0')}-${(date.getMonth() + 1).toString().padStart(2, '0')}-${date.getDate().toString().padStart(2, '0')}`,
+            ).toEqual(calendarDate.toString());
+          },
+        ),
+      );
+    });
+  });
+
   describe('Test of equals', () => {
     test('Returns true if the input object has the same unix timestamp', () => {
       fc.assert(


### PR DESCRIPTION
Added `toLocalDate` method to create a date that represents the local browser date.
#302 